### PR TITLE
Adding process signull

### DIFF
--- a/selinux-nrpe-yum.spec
+++ b/selinux-nrpe-yum.spec
@@ -6,7 +6,7 @@
 
 Name:           selinux-nrpe-%{modid}
 Version:        0.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        SELinux Policy NRPE for check_yum/check_updates
 
 Group:          Systems Environment/Policy

--- a/src/nrpe_yum.te
+++ b/src/nrpe_yum.te
@@ -7,7 +7,7 @@
 #  GH  5/6/13 v0.1: Initial revision
 #
 
-policy_module(nrpe_yum, 0.2)
+policy_module(nrpe_yum, 0.3)
 
 ## <desc>
 ## <p>
@@ -26,7 +26,7 @@ gen_tunable(nrpe_connect_network, false)
 
 require {
     type nagios_system_plugin_t;
-    class process setsched;
+    class process { signull setsched };
     class udp_socket { ioctl read write create getattr connect shutdown };
     class tcp_socket { create read write getattr getopt connect shutdown };
     class netlink_route_socket { nlmsg_read bind create getattr shutdown };
@@ -41,7 +41,7 @@ tunable_policy(`nrpe_use_yum',`
     rpm_exec(nagios_system_plugin_t)
     rpm_read_db(nagios_system_plugin_t)
     sysnet_read_config(nagios_system_plugin_t)
-    allow nagios_system_plugin_t self:process { setsched };
+    allow nagios_system_plugin_t self:process { signull setsched };
 ')
 
 tunable_policy(`nrpe_connect_network',`


### PR DESCRIPTION
Hi,
I ran into an issue with the module today.  I noticed Nagios was reporting UNKNOWN for check_yum on the server I built and installed the RPM on yesterday.  

```
YUM_Updates;UNKNOWN;HARD;4;UNKNOWN: Security plugin for YUM is required. Try to 'yum install yum-security' and then re-run this plugin. Alternatively, to just alert on any update which does not require the security plugin, try --all-updates
```

I'm not exactly sure what caused it, but I was taking a look at the sebool options and may have enabled the network access around that time.  Anyway, I ran audit2allow against my logs and found a couple of changes to the TE file to be made.

Patched the TE file and updated the versions/release, built the package and was able to do an upgrade on the existing package just fine.

We're running on a mix of OracleLinux and CentOS, both version 6.x, mostly up to date.  Test box is showing:

```
YUM_Updates;OK;HARD;4;YUM OK: 0 Security Updates Available
```
